### PR TITLE
Fix license string, add project metadata to built template

### DIFF
--- a/pyarrow/_meta_built_template.yaml
+++ b/pyarrow/_meta_built_template.yaml
@@ -6,6 +6,11 @@ package:
 source:
   url: #RELEASE_URL#
   sha256: #RELEASE_SHA256#
+about:
+  home: https://arrow.apache.org/
+  PyPI: https://pypi.org/project/pyarrow
+  summary: Python library for Apache Arrow
+  license: Apache-2.0
 requirements:
   run:
     - numpy

--- a/pyarrow/meta.yaml
+++ b/pyarrow/meta.yaml
@@ -42,7 +42,7 @@ about:
   home: https://arrow.apache.org/
   PyPI: https://pypi.org/project/pyarrow
   summary: Python library for Apache Arrow
-  license: Apache License, Version 2.0
+  license: Apache-2.0
 requirements:
   run:
     - numpy


### PR DESCRIPTION
https://github.com/pyodide/pyodide/pull/5103 updated license strings for most packages.

More context: I'm trying to upgrade to NumPy v2 in Pyodide (https://github.com/pyodide/pyodide/pull/4925) and noticed this when trying to update PyArrow here. I'll split updating PyArrow in a separate PR.